### PR TITLE
update repo name for negroni

### DIFF
--- a/config/app.go
+++ b/config/app.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-  "github.com/codegangsta/negroni"
+  "github.com/urfave/negroni"
   "github.com/gorilla/mux"
   "github.com/unrolled/render"
   "github.com/jinzhu/gorm"


### PR DESCRIPTION
"Notice: This is the library formerly known as github.com/codegangsta/cli -- Github will automatically redirect requests to this repository, but we recommend updating your references for clarity."